### PR TITLE
US582211 Bump engine.io from 6.2.0 to 6.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1377,9 +1377,9 @@
       }
     },
     "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -2667,9 +2667,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "strip-ansi": {
@@ -2678,7 +2678,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -4817,7 +4817,7 @@
           "optional": true
         },
         "ansi-regex": {
-          "version": "2.1.1",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -5263,7 +5263,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "^5.0.1"
           }
         },
         "strip-json-comments": {
@@ -5789,7 +5789,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "^5.0.1"
       }
     },
     "has-flag": {
@@ -6198,9 +6198,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "strip-ansi": {
@@ -6209,7 +6209,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -10882,9 +10882,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "strip-ansi": {
@@ -10893,7 +10893,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -10913,7 +10913,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "^5.0.1"
       }
     },
     "strip-bom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2559,7 +2559,7 @@
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
         "fsevents": "^1.2.7",
-        "glob-parent": "^3.1.0",
+        "glob-parent": "^5.1.2",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
         "is-glob": "^4.0.0",
@@ -3031,7 +3031,7 @@
       "requires": {
         "cacache": "^11.3.3",
         "find-cache-dir": "^2.1.0",
-        "glob-parent": "^3.1.0",
+        "glob-parent": "^5.1.2",
         "globby": "^7.1.1",
         "is-glob": "^4.0.1",
         "loader-utils": "^2.0.4",
@@ -5357,22 +5357,21 @@
       }
     },
     "glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
+        "is-glob": "^4.0.1"
       },
       "dependencies": {
         "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "^2.1.1"
           }
         }
       }
@@ -5385,7 +5384,7 @@
       "requires": {
         "extend": "^3.0.0",
         "glob": "^7.1.1",
-        "glob-parent": "^3.1.0",
+        "glob-parent": "^5.1.2",
         "is-negated-glob": "^1.0.0",
         "ordered-read-streams": "^1.0.0",
         "pumpify": "^1.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3968,9 +3968,9 @@
       }
     },
     "engine.io": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.0.tgz",
-      "integrity": "sha512-4KzwW3F3bk+KlzSOY57fj/Jx6LyRQ1nbcyIadehl+AnXjKT7gDO0ORdRi/84ixvMKTym6ZKuxvbzN62HDDU1Lg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
+      "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
       "dev": true,
       "requires": {
         "@types/cookie": "^0.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "license-webpack-plugin": "2.1.1",
         "loader-utils": "2.0.4",
         "mini-css-extract-plugin": "0.8.0",
-        "minimatch": "3.0.4",
+        "minimatch": "3.0.5",
         "open": "6.4.0",
         "parse5": "4.0.0",
         "postcss": "7.0.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -296,9 +296,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "get-caller-file": {
@@ -336,7 +336,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.1"
           }
         },
         "yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.0.4",
+            "minimatch": "^3.0.5",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
@@ -2423,7 +2423,7 @@
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.0.4",
+            "minimatch": "^3.0.5",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
@@ -3035,7 +3035,7 @@
         "globby": "^7.1.1",
         "is-glob": "^4.0.1",
         "loader-utils": "^2.0.4",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "normalize-path": "^3.0.0",
         "p-limit": "^2.2.0",
         "schema-utils": "^1.0.0",
@@ -4546,7 +4546,7 @@
       "dev": true,
       "requires": {
         "glob": "^7.0.3",
-        "minimatch": "^3.0.3"
+        "minimatch": "^3.0.5"
       }
     },
     "fill-range": {
@@ -4947,7 +4947,7 @@
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.0.4",
+            "minimatch": "^3.0.5",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
@@ -4973,7 +4973,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "^3.0.5"
           }
         },
         "inflight": {
@@ -5014,7 +5014,7 @@
           "optional": true
         },
         "minimatch": {
-          "version": "3.0.4",
+          "version": "3.0.5",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -5351,7 +5351,7 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -6089,7 +6089,7 @@
       "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "dev": true,
       "requires": {
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       }
     },
     "image-size": {
@@ -6598,7 +6598,7 @@
         "istanbul-reports": "^2.2.4",
         "js-yaml": "^3.13.1",
         "make-dir": "^2.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "once": "^1.4.0"
       },
       "dependencies": {
@@ -6976,7 +6976,7 @@
         "lodash": "^4.17.21",
         "log4js": "^6.4.1",
         "mime": "^2.5.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "mkdirp": "^0.5.5",
         "qjobs": "^1.2.0",
         "range-parser": "^1.2.1",
@@ -7283,7 +7283,7 @@
       "dev": true,
       "requires": {
         "istanbul-api": "^2.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       }
     },
     "karma-jasmine": {
@@ -7653,7 +7653,7 @@
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.0.4",
+            "minimatch": "^3.0.5",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
@@ -7886,9 +7886,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -8635,7 +8635,7 @@
         "glob": "^7.1.3",
         "lru-cache": "^5.1.1",
         "make-fetch-happen": "^5.0.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "minipass": "^2.3.5",
         "mississippi": "^3.0.0",
         "mkdirp": "^0.5.1",
@@ -8689,7 +8689,7 @@
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^3.0.4",
+                "minimatch": "^3.0.5",
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
               }
@@ -10965,7 +10965,7 @@
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.0.2",
+            "minimatch": "^3.0.5",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
@@ -11356,7 +11356,7 @@
         "diff": "^3.2.0",
         "glob": "^7.1.1",
         "js-yaml": "^3.13.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=582211

Alerts covered:
https://github.com/MicroFocus/microfocus.github.io/security/dependabot/40
https://github.com/MicroFocus/microfocus.github.io/security/dependabot/98
https://github.com/MicroFocus/microfocus.github.io/security/dependabot/99
https://github.com/MicroFocus/microfocus.github.io/security/dependabot/100
https://github.com/MicroFocus/microfocus.github.io/security/dependabot/104